### PR TITLE
chore(template): accept new copier update

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: v0.8.0-14-g1c9f8c8
+_commit: v0.8.0-28-gec8e125
 _src_path: https://github.com/usnistgov/cookiecutter-nist-python.git
 command_line_interface: none
 conda_channel: conda-forge

--- a/.github/workflows/update-copier.yml
+++ b/.github/workflows/update-copier.yml
@@ -129,3 +129,14 @@ jobs:
           echo "Pull Request SHA       - $SHA"
           echo "Pull Request BRANCH    - $BRANCH"
           echo "Pull Request VERIFIED  - $VERIFIED"
+
+      # - name: automerge
+      #   if:
+      #     ${{ steps.cpr.outputs.pull-request-number &&
+      #     steps.check.outputs.conflict_message == '' }}
+      #   env:
+      #     NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+      #     # Need PAT if want to start other actions.  Use GITHUB_TOKEN if not.
+      #     GH_TOKEN: ${{ secrets.PAT }}
+      #   run: |
+      #     gh pr merge -m --auto "$NUMBER"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -110,7 +110,7 @@ repos:
 
   # * Linting
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.6
+    rev: v0.15.7
     hooks:
       - id: ruff-check
         alias: ruff
@@ -130,7 +130,7 @@ repos:
           - "--command"
           - "ruff format"
         additional_dependencies:
-          - ruff==0.15.6
+          - ruff==0.15.7
 
   # * Spelling
   # ** typos
@@ -152,7 +152,7 @@ repos:
           - "--custom-command=prek run pyproject2conda-project --all-files"
   # ** uv
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.10.11
+    rev: 0.10.12
     hooks:
       - id: uv-lock
         alias: requirements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -395,7 +395,7 @@ major-labels = [ "breaking" ]
 minor_labels = [ "enhancement" ]
 patch-labels = [ "bug", "documentation" ]
 # options
-ignore-labels = [ "internal", "testing" ]
+ignore-labels = [ "internal" ]
 require-labels = [ "breaking", "bug", "documentation", "enhancement" ]
 version_files = [
     "pyproject.toml",


### PR DESCRIPTION
This is an autogenerated PR. Use this to merge the changes to this repository. 

Files changed (`git status --short`):
 M .copier-answers.yml
 M .github/workflows/update-copier.yml
 M .pre-commit-config.yaml
 M pyproject.toml

[copier](https://github.com/copier-org/copier) has detected updates from the Cookiecutter repository.