### PR TITLE
chore(template): accept new copier update

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: v0.11.0-2-ga4e3723
+_commit: v0.11.0-7-g0d0a7bc
 _src_path: https://github.com/usnistgov/cookiecutter-nist-python.git
 command_line_interface: none
 conda_channel: conda-forge

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
           echo "prek_version=${prek_version}" >> "$GITHUB_ENV"
 
       - name: Setup prek
-        uses: j178/prek-action@79f765515bd648eb4d6bb1b17277b7cb22cb6468 # v2.0.0
+        uses: j178/prek-action@53276d8b0d10f8b6672aa85b4588c6921d0370cc # v2.0.1
         with:
           prek-version: ${{ env.prek_version }}
           install-only: true

--- a/tools/requirements_lock.py
+++ b/tools/requirements_lock.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from subprocess import check_call
 from typing import TYPE_CHECKING
 
+import tomllib
+
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
@@ -105,6 +107,13 @@ def _maybe_copy_lockfile(lock_path: Path) -> Path | None:
     if not lock_path.exists():
         return None
 
+    try:
+        _ = tomllib.loads(lock_path.read_text(encoding="utf-8"))["options"][
+            "exclude-newer"
+        ]
+    except KeyError:
+        return None
+
     # copy lockfile to temp location
     import tempfile
 
@@ -116,11 +125,10 @@ def _maybe_copy_lockfile(lock_path: Path) -> Path | None:
 
 
 def _only_changed_exclude_newer_time(old_path: Path, new_path: Path) -> bool:
-    import tomllib
-
     old_data, new_data = (
         tomllib.loads(path.read_text(encoding="utf-8")) for path in (old_path, new_path)
     )
+
     old_data["options"]["exclude-newer"] = "0"
     new_data["options"]["exclude-newer"] = "0"
     return old_data == new_data


### PR DESCRIPTION
This is an autogenerated PR. Use this to merge the changes to this repository. 

Files changed (`git status --short`):
 M .copier-answers.yml
 M .github/workflows/ci.yml
 M tools/requirements_lock.py

[copier](https://github.com/copier-org/copier) has detected updates from the Cookiecutter repository.