### PR TITLE
chore(template): accept new copier update

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: v0.12.0-61-g4fbc986
+_commit: v0.12.0-67-gdc77255
 _src_path: https://github.com/usnistgov/cookiecutter-nist-python.git
 command_line_interface: none
 conda_channel: conda-forge

--- a/.github/workflows/update-copier.yml
+++ b/.github/workflows/update-copier.yml
@@ -105,10 +105,18 @@ jobs:
           fi
         shell: bash -eux {0}
 
+      - name: Install just
+        if: steps.check.outputs.changed == 'true'
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+
+      - name: Sync requirements
+        if: steps.check.outputs.changed == 'true'
+        run: just lock
+
       - name: Create pull request
         if: steps.check.outputs.changed == 'true'
         id: cpr
-        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.PAT }}
           add-paths: ${{ matrix.add-paths }}


### PR DESCRIPTION
This is an autogenerated PR. Use this to merge the changes to this repository. 

Files changed (`git status --short`):
 M .copier-answers.yml
 M .github/workflows/update-copier.yml

[copier](https://github.com/copier-org/copier) has detected updates from the Cookiecutter repository.