### PR TITLE
chore(template): accept new copier update

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: v0.12.0-164-geb1ff28
+_commit: v0.12.0-166-g03a288c
 _src_path: https://github.com/usnistgov/cookiecutter-nist-python.git
 command_line_interface: none
 conda_channel: conda-forge

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,7 +97,7 @@ repos:
 
   # * Linting
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.12
+    rev: v0.15.13
     hooks:
       - id: ruff-check
         alias: ruff


### PR DESCRIPTION
This is an autogenerated PR. Use this to merge the changes to this repository. 

Files changed (`git status --short`):
 M .copier-answers.yml
 M .pre-commit-config.yaml

[copier](https://github.com/copier-org/copier) has detected updates from the Cookiecutter repository.